### PR TITLE
Remove trailing slashes from server url / Missing space

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: "Bundesagentur für Arbeit: Jobsuche API"
 
 servers:
-  - url: "https://api-con.arbeitsagentur.de/prod/jobboerse/jobsuche-service/"
+  - url: "https://api-con.arbeitsagentur.de/prod/jobboerse/jobsuche-service"
 
 paths:
   /pc/v2/app/jobs/:
@@ -201,7 +201,7 @@ components:
   securitySchemes:
     clientCredAuth:    # <---- arbitrary name
       type: oauth2
-      description: "Die Authentifizierung funktioniert per OAuth 2 Client Credentials mit JWTs.Die Client Credentials sind z.B. in der App hinterlegt:<br><br> **ClientID:** c003a37f-024f-462a-b36d-b001be4cd24a <br> **ClientSecret:** 32a39620-32b3-4307-9aa1-511e3d7f48a8"
+      description: "Die Authentifizierung funktioniert per OAuth 2 Client Credentials mit JWTs. Die Client Credentials sind z.B. in der App hinterlegt:<br><br> **ClientID:** c003a37f-024f-462a-b36d-b001be4cd24a <br> **ClientSecret:** 32a39620-32b3-4307-9aa1-511e3d7f48a8"
       flows:
         clientCredentials:  
           tokenUrl: https://api-con.arbeitsagentur.de/oauth/gettoken_cc


### PR DESCRIPTION
According to the OpenAPI specifications, the server addresses must not end on a slash (see https://swagger.io/specification/#server-object). Importing this in tools like Postman generates defective URLs containing two slashes. This PR fixes this.

A space was missing from a line.