### PR TITLE
Added empty scope definition to oauth2 authentication flow

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -205,6 +205,7 @@ components:
       flows:
         clientCredentials:  
           tokenUrl: https://api-con.arbeitsagentur.de/oauth/gettoken_cc
+          scopes: {}
   schemas:
     
     JobSearchResponse:


### PR DESCRIPTION
scope definition is required for "openapi-python-client" to work

Fixes #5 

