### PR TITLE
Fix Copy-paste error

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -53,7 +53,7 @@ paths:
           schema:
             type: string
           example: Deutsche%20Bahn%20AG_W4qFQypjw_IWOJAkn2NMSE-Yf-mRbt_6_PvZr0FLdX4%3D
-          description: Anzahl von Ergebnissen
+          description: Arbeitgeber der Stelle
           required: false
         - in: query
           name: FCT.AKTUALITAET 


### PR DESCRIPTION
Trivial Copy-Paste error.

Note: I could not verify that the parameter works at all… The website uses v4 of the API, there it works (with just the name of the company no hash needed). So it might be better to "upgrade" to v4 in general? But that would be a separate, bigger PR.