### PR TITLE
remove /pc/v2/jobs/{hashId}/bewerbung

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -142,27 +142,7 @@ paths:
             content:
               application/json:
                 schema:
-                  $ref: '#/components/schemas/JobDetails'
-  
-  /pc/v2/app/jobs/{hashID}/bewerbung:
-    get:
-      summary: Bewerbung Kontaktdaten
-      description: "Abrufen von Kontaktdaten zu einem Job. Dieser Endpunkt benötigt Captcha-Headers."
-      parameters:
-        - name: hashID
-          in: path
-          required: true
-          schema:
-            type: string
-            example: VK2qoXBe0s-UAdH_qxLDRrZrY5iY8a1PJt3MjJCXsdo=
-      responses:
-        '200':
-            description: OK
-            content:
-              application/json:
-                schema:
-                  $ref: '#/components/schemas/JobApplicationDetails'
-                  
+                  $ref: '#/components/schemas/JobDetails'                   
   
   /ed/v1/arbeitgeberlogo/{hashID}:
     get:

--- a/python-client/README.md
+++ b/python-client/README.md
@@ -50,7 +50,6 @@ import time
 from deutschland import jobsuche
 from pprint import pprint
 from deutschland.jobsuche.api import default_api
-from deutschland.jobsuche.model.job_application_details import JobApplicationDetails
 from deutschland.jobsuche.model.job_details import JobDetails
 from deutschland.jobsuche.model.job_search_response import JobSearchResponse
 # Defining the host is optional and defaults to https://rest.arbeitsagentur.de/jobboerse/jobsuche-service
@@ -92,7 +91,6 @@ All URIs are relative to *https://rest.arbeitsagentur.de/jobboerse/jobsuche-serv
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
 *DefaultApi* | [**ed_v1_arbeitgeberlogo_hash_id_get**](docs/DefaultApi.md#ed_v1_arbeitgeberlogo_hash_id_get) | **GET** /ed/v1/arbeitgeberlogo/{hashID} | Unternehmen Logo
-*DefaultApi* | [**pc_v2_app_jobs_hash_id_bewerbung_get**](docs/DefaultApi.md#pc_v2_app_jobs_hash_id_bewerbung_get) | **GET** /pc/v2/app/jobs/{hashID}/bewerbung | Bewerbung Kontaktdaten
 *DefaultApi* | [**pc_v2_jobdetails_hash_id_get**](docs/DefaultApi.md#pc_v2_jobdetails_hash_id_get) | **GET** /pc/v2/jobdetails/{hashID} | Jobdetail
 *DefaultApi* | [**pc_v4_app_jobs_get**](docs/DefaultApi.md#pc_v4_app_jobs_get) | **GET** /pc/v4/app/jobs | Jobsuche
 

--- a/python-client/deutschland/jobsuche/api/default_api.py
+++ b/python-client/deutschland/jobsuche/api/default_api.py
@@ -14,7 +14,6 @@ import sys  # noqa: F401
 
 from deutschland.jobsuche.api_client import ApiClient
 from deutschland.jobsuche.api_client import Endpoint as _Endpoint
-from deutschland.jobsuche.model.job_application_details import JobApplicationDetails
 from deutschland.jobsuche.model.job_details import JobDetails
 from deutschland.jobsuche.model.job_search_response import JobSearchResponse
 from deutschland.jobsuche.model_utils import (  # noqa: F401
@@ -75,46 +74,6 @@ class DefaultApi(object):
             },
             headers_map={
                 "accept": ["image/png"],
-                "content_type": [],
-            },
-            api_client=api_client,
-        )
-        self.pc_v2_app_jobs_hash_id_bewerbung_get_endpoint = _Endpoint(
-            settings={
-                "response_type": (JobApplicationDetails,),
-                "auth": ["clientCredAuth"],
-                "endpoint_path": "/pc/v2/app/jobs/{hashID}/bewerbung",
-                "operation_id": "pc_v2_app_jobs_hash_id_bewerbung_get",
-                "http_method": "GET",
-                "servers": None,
-            },
-            params_map={
-                "all": [
-                    "hash_id",
-                ],
-                "required": [
-                    "hash_id",
-                ],
-                "nullable": [],
-                "enum": [],
-                "validation": [],
-            },
-            root_map={
-                "validations": {},
-                "allowed_values": {},
-                "openapi_types": {
-                    "hash_id": (str,),
-                },
-                "attribute_map": {
-                    "hash_id": "hashID",
-                },
-                "location_map": {
-                    "hash_id": "path",
-                },
-                "collection_format_map": {},
-            },
-            headers_map={
-                "accept": ["application/json"],
                 "content_type": [],
             },
             api_client=api_client,
@@ -322,71 +281,6 @@ class DefaultApi(object):
         kwargs["_request_auths"] = kwargs.get("_request_auths", None)
         kwargs["hash_id"] = hash_id
         return self.ed_v1_arbeitgeberlogo_hash_id_get_endpoint.call_with_http_info(
-            **kwargs
-        )
-
-    def pc_v2_app_jobs_hash_id_bewerbung_get(self, hash_id, **kwargs):
-        """Bewerbung Kontaktdaten  # noqa: E501
-
-        Abrufen von Kontaktdaten zu einem Job. Dieser Endpunkt benötigt Captcha-Headers.  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.pc_v2_app_jobs_hash_id_bewerbung_get(hash_id, async_req=True)
-        >>> result = thread.get()
-
-        Args:
-            hash_id (str):
-
-        Keyword Args:
-            _return_http_data_only (bool): response data without head status
-                code and headers. Default is True.
-            _preload_content (bool): if False, the urllib3.HTTPResponse object
-                will be returned without reading/decoding response data.
-                Default is True.
-            _request_timeout (int/float/tuple): timeout setting for this request. If
-                one number provided, it will be total request timeout. It can also
-                be a pair (tuple) of (connection, read) timeouts.
-                Default is None.
-            _check_input_type (bool): specifies if type checking
-                should be done one the data sent to the server.
-                Default is True.
-            _check_return_type (bool): specifies if type checking
-                should be done one the data received from the server.
-                Default is True.
-            _spec_property_naming (bool): True if the variable names in the input data
-                are serialized names, as specified in the OpenAPI document.
-                False if the variable names in the input data
-                are pythonic names, e.g. snake case (default)
-            _content_type (str/None): force body content-type.
-                Default is None and content-type will be predicted by allowed
-                content-types and body.
-            _host_index (int/None): specifies the index of the server
-                that we want to use.
-                Default is read from the configuration.
-            _request_auths (list): set to override the auth_settings for an a single
-                request; this effectively ignores the authentication
-                in the spec for a single request.
-                Default is None
-            async_req (bool): execute request asynchronously
-
-        Returns:
-            JobApplicationDetails
-                If the method is called asynchronously, returns the request
-                thread.
-        """
-        kwargs["async_req"] = kwargs.get("async_req", False)
-        kwargs["_return_http_data_only"] = kwargs.get("_return_http_data_only", True)
-        kwargs["_preload_content"] = kwargs.get("_preload_content", True)
-        kwargs["_request_timeout"] = kwargs.get("_request_timeout", None)
-        kwargs["_check_input_type"] = kwargs.get("_check_input_type", True)
-        kwargs["_check_return_type"] = kwargs.get("_check_return_type", True)
-        kwargs["_spec_property_naming"] = kwargs.get("_spec_property_naming", False)
-        kwargs["_content_type"] = kwargs.get("_content_type")
-        kwargs["_host_index"] = kwargs.get("_host_index")
-        kwargs["_request_auths"] = kwargs.get("_request_auths", None)
-        kwargs["hash_id"] = hash_id
-        return self.pc_v2_app_jobs_hash_id_bewerbung_get_endpoint.call_with_http_info(
             **kwargs
         )
 

--- a/python-client/docs/DefaultApi.md
+++ b/python-client/docs/DefaultApi.md
@@ -5,7 +5,6 @@ All URIs are relative to *https://rest.arbeitsagentur.de/jobboerse/jobsuche-serv
 Method | HTTP request | Description
 ------------- | ------------- | -------------
 [**ed_v1_arbeitgeberlogo_hash_id_get**](DefaultApi.md#ed_v1_arbeitgeberlogo_hash_id_get) | **GET** /ed/v1/arbeitgeberlogo/{hashID} | Unternehmen Logo
-[**pc_v2_app_jobs_hash_id_bewerbung_get**](DefaultApi.md#pc_v2_app_jobs_hash_id_bewerbung_get) | **GET** /pc/v2/app/jobs/{hashID}/bewerbung | Bewerbung Kontaktdaten
 [**pc_v2_jobdetails_hash_id_get**](DefaultApi.md#pc_v2_jobdetails_hash_id_get) | **GET** /pc/v2/jobdetails/{hashID} | Jobdetail
 [**pc_v4_app_jobs_get**](DefaultApi.md#pc_v4_app_jobs_get) | **GET** /pc/v4/app/jobs | Jobsuche
 
@@ -77,84 +76,6 @@ Name | Type | Description  | Notes
 
  - **Content-Type**: Not defined
  - **Accept**: image/png
-
-
-### HTTP response details
-
-| Status code | Description | Response headers |
-|-------------|-------------|------------------|
-**200** | OK |  -  |
-
-[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
-
-# **pc_v2_app_jobs_hash_id_bewerbung_get**
-> JobApplicationDetails pc_v2_app_jobs_hash_id_bewerbung_get(hash_id)
-
-Bewerbung Kontaktdaten
-
-Abrufen von Kontaktdaten zu einem Job. Dieser Endpunkt benötigt Captcha-Headers.
-
-### Example
-
-* OAuth Authentication (clientCredAuth):
-
-```python
-import time
-from deutschland import jobsuche
-from deutschland.jobsuche.api import default_api
-from deutschland.jobsuche.model.job_application_details import JobApplicationDetails
-from pprint import pprint
-# Defining the host is optional and defaults to https://rest.arbeitsagentur.de/jobboerse/jobsuche-service
-# See configuration.py for a list of all supported configuration parameters.
-configuration = jobsuche.Configuration(
-    host = "https://rest.arbeitsagentur.de/jobboerse/jobsuche-service"
-)
-
-# The client must configure the authentication and authorization parameters
-# in accordance with the API server security policy.
-# Examples for each auth method are provided below, use the example that
-# satisfies your auth use case.
-
-# Configure OAuth2 access token for authorization: clientCredAuth
-configuration = jobsuche.Configuration(
-    host = "https://rest.arbeitsagentur.de/jobboerse/jobsuche-service"
-)
-configuration.access_token = 'YOUR_ACCESS_TOKEN'
-
-# Enter a context with an instance of the API client
-with jobsuche.ApiClient(configuration) as api_client:
-    # Create an instance of the API class
-    api_instance = default_api.DefaultApi(api_client)
-    hash_id = "VK2qoXBe0s-UAdH_qxLDRrZrY5iY8a1PJt3MjJCXsdo=" # str | 
-
-    # example passing only required values which don't have defaults set
-    try:
-        # Bewerbung Kontaktdaten
-        api_response = api_instance.pc_v2_app_jobs_hash_id_bewerbung_get(hash_id)
-        pprint(api_response)
-    except jobsuche.ApiException as e:
-        print("Exception when calling DefaultApi->pc_v2_app_jobs_hash_id_bewerbung_get: %s\n" % e)
-```
-
-
-### Parameters
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **hash_id** | **str**|  |
-
-### Return type
-
-[**JobApplicationDetails**](JobApplicationDetails.md)
-
-### Authorization
-
-[clientCredAuth](../README.md#clientCredAuth)
-
-### HTTP request headers
-
- - **Content-Type**: Not defined
- - **Accept**: application/json
 
 
 ### HTTP response details

--- a/python-client/test/test_default_api.py
+++ b/python-client/test/test_default_api.py
@@ -32,13 +32,6 @@ class TestDefaultApi(unittest.TestCase):
         """
         pass
 
-    def test_pc_v2_app_jobs_hash_id_bewerbung_get(self):
-        """Test case for pc_v2_app_jobs_hash_id_bewerbung_get
-
-        Bewerbung Kontaktdaten  # noqa: E501
-        """
-        pass
-
     def test_pc_v2_jobdetails_hash_id_get(self):
         """Test case for pc_v2_jobdetails_hash_id_get
 


### PR DESCRIPTION
Da Zugriff auf /pc/v2/jobs/{hashId}/bewerbung bisher unzureichend dokumentiert ist, würde ich vorschlagen, ihn bis auf Weiteres von der Dokumentation auszunehmen.

closes #13 & closes #19