### PR TITLE
Add quotes to pip package name for shell support

### DIFF
--- a/python-client/README.md
+++ b/python-client/README.md
@@ -15,7 +15,7 @@ Python >= 3.6
 ### pip install
 
 ```sh
-pip install deutschland[jobsuche]
+pip install 'deutschland[jobsuche]'
 ```
 
 ### poetry install


### PR DESCRIPTION
ZSH does not support the current command. By adding quotes to the package name it works.