### PR TITLE
OpenAPI change encodedHash to encodedRefNr due to upstream change

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -258,18 +258,18 @@ paths:
           example: 25
           required: false
 
-  /pc/v2/jobdetails/{encodedHashID}:
+  /pc/v2/jobdetails/{encodedRefNr}:
     get:
       summary: Jobdetail
       description: "Abrufen von Details zu einem Job."
       parameters:
-        - name: encodedHashID
+        - name: encodedRefNr
           in: path
           required: true
           schema:
             type: string
-            example: VK2qoXBe0s-UAdH_qxLDRrZrY5iY8a1PJt3MjJCXsdo=
-          description: Hash-ID eines Jobs (siehe JobSearchResponse), enkodiert mit Base64
+            example: MTIyNjUtMzM4MTI3X0pCNDA4NjkzMy1T
+          description: refnr (z.B. 12265-338127_JB4086933-S siehe JobSearchResponse), enkodiert mit Base64 (z.B. MTIyNjUtMzM4MTI3X0pCNDA4NjkzMy1T) und wenn vorhanden das letzte = abgeschnitten.
       responses:
         '200':
             description: OK


### PR DESCRIPTION
Vermutlich hat sich etwas upstream geändert. Ich habe einiges probiert und dokumentiere hiermit die Änderung des job details Endpunktes.

Die `hashId` scheint nicht mehr im Details Endpunkt verwendet zu werden.
Vorher: `CJG31V0qV5xRHnTpq3r4-tAVAQ1TKZ84Yy55-JLx4A0=`
In der tatsächlichen Abfrage: `MTI3MjctVUwxMzY5MzM5LVM`

Hier meine Quelle: (main bundle ~Zeile 5070)
```JS
getStellendetails(_DEMINIFIED_JOB_REF_NR) {
    return (
        (0, F.PM) (_DEMINIFIED_LITERAL("browser"))
        && (_DEMINIFIED_JOB_REF_NR = decodeURIComponent(_DEMINIFIED_JOB_REF_NR)),
        this.appConfig.getEndpoint("jobdetails").pipe((0, _.w)(ce => this.http.get(ce.toUrl() + "/" + i()(_DEMINIFIED_JOB_REF_NR), {})), (0, M.b)(ce => {
        (0, F.PM)(_DEMINIFIED_LITERAL("browser")) && this.transferState.set(q.JOBDETAIL_STATE_KEY, ce)
        }), (0, p.q)(1))
    );
}
```

Jetzt wird die `Job Ref Nr` verwendet. Diese wird per base64 kodiert und alle = werden abgeschnitten.

Ich habe dies über die API als auch mit Hilfe von Debugging der echten Anwendung bestätigt.

Was ggf. noch sein könnte ist, dass alle alten Jobs noch das alte System verwenden. Das kann ich dem Quellcode zwar so nicht entnehmen, aber ich könnte es übersehen haben. Um dies praktisch überprüfen zu können, bräuchte ich einen möglichst alten Joblink.

Frohe Weihnachten!